### PR TITLE
if twigletInfoOrError is an error there will be no twiglet data -- so…

### DIFF
--- a/src/api/v2/twiglets/twiglets.e2e.js
+++ b/src/api/v2/twiglets/twiglets.e2e.js
@@ -714,7 +714,7 @@ describe('twiglets', () => {
       });
 
       // TODO: this on aws this returns a 500 - fix and uncomment
-      it('GET twiglet returns 404', async () => {
+      it.only('GET twiglet returns 404', async () => {
         res = await getTwiglet({ name: baseTwiglet().name });
         expect(res).to.have.status(404);
       });

--- a/src/api/v2/twiglets/twiglets.js
+++ b/src/api/v2/twiglets/twiglets.js
@@ -309,6 +309,9 @@ async function getTwiglet (name, urlBuilder, contextualConfig) {
     contextualConfig,
     twigletKeys: ['nodes', 'links', 'changelog'],
   });
+  if (twigletInfoOrError instanceof Error) {
+    throw twigletInfoOrError;
+  }
   console.log('after getTwigletInfoDbAndData');
   const cleanedTwigletData = R.omit(['changelog', 'views_2', 'events', 'sequences'], twigletData);
   console.log('after cleanedTwigletData');


### PR DESCRIPTION
… we should throw that error early, becuase the server cares, even though the local environment did not care.