### PR TITLE
throw twiglet exists error instead of console.error

### DIFF
--- a/src/db-init/init-new-db.js
+++ b/src/db-init/init-new-db.js
@@ -39,7 +39,7 @@ function importTwiglets (twigletsArray) {
   twigletsArray.forEach(twiglet => twigletLookupDb.allDocs({ include_docs: true })
     .then((docs) => {
       if (docs.rows.some(row => row.doc.name === twiglet.name)) {
-        return console.error(`Twiglet with a name ${twiglet.name} already exists, not imported`);
+        throw new Error(`Twiglet with a name ${twiglet.name} already exists, not imported`);
       }
       const newTwiglet = { name: twiglet.name, description: twiglet.description };
       newTwiglet._id = `twig-${uuidV4()}`;


### PR DESCRIPTION
this fixes the 'Problem with Twigception TypeError: Cannot read property 'id' of undefined' error we've been getting when importing Twigception when it already exists in the db